### PR TITLE
Finish up/flesh out the 'label' clause.

### DIFF
--- a/clause/label/label.go
+++ b/clause/label/label.go
@@ -1,6 +1,8 @@
 package label
 
 import (
+	"fmt"
+
 	"github.com/cyverse-de/querydsl"
 	"github.com/cyverse-de/querydsl/clause"
 	"github.com/cyverse-de/querydsl/clauseutils"
@@ -35,7 +37,7 @@ func LabelProcessor(args map[string]interface{}) (elastic.Query, error) {
 	}
 
 	processedQuery := clauseutils.AddImplicitWildcard(clauseutils.AddOrOperator(realArgs.Label))
-	query := elastic.NewQueryStringQuery(processedQuery).Field("label")
+	query := elastic.NewQueryStringQuery(processedQuery).Field("label").QueryName(fmt.Sprintf("label: %q", realArgs.Label))
 	return query, nil
 }
 

--- a/clause/label/label.go
+++ b/clause/label/label.go
@@ -3,6 +3,7 @@ package label
 import (
 	"github.com/cyverse-de/querydsl"
 	"github.com/cyverse-de/querydsl/clause"
+	"github.com/cyverse-de/querydsl/clauseutils"
 	"github.com/mitchellh/mapstructure"
 	"gopkg.in/olivere/elastic.v5"
 )
@@ -33,7 +34,8 @@ func LabelProcessor(args map[string]interface{}) (elastic.Query, error) {
 		return nil, err
 	}
 
-	query := elastic.NewQueryStringQuery(realArgs.Label).Field("label")
+	withOrOperator := clauseutils.AddOrOperator(realArgs.Label)
+	query := elastic.NewQueryStringQuery(withOrOperator).Field("label")
 	return query, nil
 }
 

--- a/clause/label/label.go
+++ b/clause/label/label.go
@@ -34,8 +34,8 @@ func LabelProcessor(args map[string]interface{}) (elastic.Query, error) {
 		return nil, err
 	}
 
-	withOrOperator := clauseutils.AddOrOperator(realArgs.Label)
-	query := elastic.NewQueryStringQuery(withOrOperator).Field("label")
+	processedQuery := clauseutils.AddImplicitWildcard(clauseutils.AddOrOperator(realArgs.Label))
+	query := elastic.NewQueryStringQuery(processedQuery).Field("label")
 	return query, nil
 }
 

--- a/clause/label/label.go
+++ b/clause/label/label.go
@@ -27,7 +27,6 @@ var (
 
 type LabelArgs struct {
 	Label string
-	// Negation bool // TODO
 	Exact bool
 }
 

--- a/clause/label/label.go
+++ b/clause/label/label.go
@@ -1,6 +1,7 @@
 package label
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/cyverse-de/querydsl"
@@ -35,6 +36,10 @@ func LabelProcessor(args map[string]interface{}) (elastic.Query, error) {
 	err := mapstructure.Decode(args, &realArgs)
 	if err != nil {
 		return nil, err
+	}
+
+	if realArgs.Label == "" {
+		return nil, errors.New("No label was passed, cannot create clause.")
 	}
 
 	var processedQuery string

--- a/clause/label/label.go
+++ b/clause/label/label.go
@@ -45,7 +45,7 @@ func LabelProcessor(args map[string]interface{}) (elastic.Query, error) {
 	if realArgs.Exact {
 		processedQuery = realArgs.Label
 	} else {
-		processedQuery = clauseutils.AddImplicitWildcard(clauseutils.AddOrOperator(realArgs.Label))
+		processedQuery = clauseutils.AddImplicitWildcard(realArgs.Label)
 	}
 	query := elastic.NewQueryStringQuery(processedQuery).Field("label").QueryName(fmt.Sprintf("label: %q", realArgs.Label))
 	return query, nil

--- a/clause/label/label_test.go
+++ b/clause/label/label_test.go
@@ -41,7 +41,7 @@ func TestLabelProcessor(t *testing.T) {
 		t.Error("query did not contain 'query'")
 	}
 
-	if stringQuery.(string) != "foo OR bar" {
-		t.Errorf("query %q did not match expected value %q", stringQuery, "foo OR bar")
+	if stringQuery.(string) != "*foo* OR *bar*" {
+		t.Errorf("query %q did not match expected value %q", stringQuery, "*foo* OR *bar*")
 	}
 }

--- a/clause/label/label_test.go
+++ b/clause/label/label_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestLabelProcessor(t *testing.T) {
 	cases := []struct {
-		label         string
+		label         interface{}
 		exact         string // "true", "false", or "nil" to not set
 		expectedQuery string
 		shouldErr     bool
@@ -14,7 +14,8 @@ func TestLabelProcessor(t *testing.T) {
 		{label: "foo bar", exact: "nil", expectedQuery: "*foo* OR *bar*"},
 		{label: "foo bar", exact: "false", expectedQuery: "*foo* OR *bar*"},
 		{label: "foo bar", exact: "true", expectedQuery: "foo bar"},
-		{exact: "nil", expectedQuery: "", shouldErr: true},
+		{exact: "nil", shouldErr: true},             // empty label
+		{label: 444, exact: "nil", shouldErr: true}, // bad type
 	}
 
 	for _, c := range cases {

--- a/clause/label/label_test.go
+++ b/clause/label/label_test.go
@@ -7,7 +7,7 @@ import (
 func TestLabelProcessor(t *testing.T) {
 	args := make(map[string]interface{})
 
-	args["label"] = "foo"
+	args["label"] = "foo bar"
 
 	query, err := LabelProcessor(args)
 	if err != nil {
@@ -41,7 +41,7 @@ func TestLabelProcessor(t *testing.T) {
 		t.Error("query did not contain 'query'")
 	}
 
-	if stringQuery.(string) != "foo" {
-		t.Error("query did not match expected value")
+	if stringQuery.(string) != "foo OR bar" {
+		t.Errorf("query %q did not match expected value %q", stringQuery, "foo OR bar")
 	}
 }

--- a/clause/label/label_test.go
+++ b/clause/label/label_test.go
@@ -11,9 +11,10 @@ func TestLabelProcessor(t *testing.T) {
 		expectedQuery string
 		shouldErr     bool
 	}{
-		{label: "foo bar", exact: "nil", expectedQuery: "*foo* OR *bar*"},
-		{label: "foo bar", exact: "false", expectedQuery: "*foo* OR *bar*"},
+		{label: "foo bar", exact: "nil", expectedQuery: "*foo* *bar*"},
+		{label: "foo bar", exact: "false", expectedQuery: "*foo* *bar*"},
 		{label: "foo bar", exact: "true", expectedQuery: "foo bar"},
+		{label: "\"foo bar\"", exact: "false", expectedQuery: "\"foo bar\""},
 		{exact: "nil", shouldErr: true},             // empty label
 		{label: 444, exact: "nil", shouldErr: true}, // bad type
 	}

--- a/clauseutils/clauseutils.go
+++ b/clauseutils/clauseutils.go
@@ -6,28 +6,15 @@ import (
 	"strings"
 )
 
-// AddOrOperator takes whitespace and turns it into the OR operator, for a query string
-func AddOrOperator(input string) string {
-	inputSplit := strings.Split(input, " ")
-	var rejoin []string
-	blank := regexp.MustCompile(`^\s*$`)
-	for _, part := range inputSplit {
-		if !blank.MatchString(part) {
-			rejoin = append(rejoin, strings.TrimSpace(part))
-		}
-	}
-
-	return strings.Join(rejoin, " OR ")
-}
-
 // AddImplicitWildcard takes a query string with OR operators and adds wildcards around each piece separated by OR, unless the query already has wildcard-y syntax
 func AddImplicitWildcard(input string) string {
-	haswild := regexp.MustCompile(`[*?\\]`)
+	haswild := regexp.MustCompile(`[*?\\"]`)
 	if haswild.MatchString(input) {
 		return input
 	}
 
-	inputSplit := strings.Split(input, " OR ")
+	splitRegex := regexp.MustCompile(`( OR |\s+)`)
+	inputSplit := splitRegex.Split(input, -1)
 	var rejoin []string
 
 	blank := regexp.MustCompile(`^\s*$`)
@@ -37,5 +24,5 @@ func AddImplicitWildcard(input string) string {
 		}
 	}
 
-	return strings.Join(rejoin, " OR ")
+	return strings.Join(rejoin, " ")
 }

--- a/clauseutils/clauseutils.go
+++ b/clauseutils/clauseutils.go
@@ -19,3 +19,23 @@ func AddOrOperator(input string) string {
 
 	return strings.Join(rejoin, " OR ")
 }
+
+// AddImplicitWildcard takes a query string with OR operators and adds wildcards around each piece separated by OR, unless the query already has wildcard-y syntax
+func AddImplicitWildcard(input string) string {
+	haswild := regexp.MustCompile(`[*?\\]`)
+	if haswild.MatchString(input) {
+		return input
+	}
+
+	inputSplit := strings.Split(input, " OR ")
+	var rejoin []string
+
+	blank := regexp.MustCompile(`^\s*$`)
+	for _, part := range inputSplit {
+		if !blank.MatchString(part) {
+			rejoin = append(rejoin, "*"+strings.TrimSpace(part)+"*")
+		}
+	}
+
+	return strings.Join(rejoin, " OR ")
+}

--- a/clauseutils/clauseutils.go
+++ b/clauseutils/clauseutils.go
@@ -1,0 +1,21 @@
+// Package clauseutils provides various useful functions for clauses to use in their processing
+package clauseutils
+
+import (
+	"regexp"
+	"strings"
+)
+
+// AddOrOperator takes whitespace and turns it into the OR operator, for a query string
+func AddOrOperator(input string) string {
+	inputSplit := strings.Split(input, " ")
+	var rejoin []string
+	blank := regexp.MustCompile(`^\s*$`)
+	for _, part := range inputSplit {
+		if !blank.MatchString(part) {
+			rejoin = append(rejoin, strings.TrimSpace(part))
+		}
+	}
+
+	return strings.Join(rejoin, " OR ")
+}

--- a/clauseutils/clauseutils_test.go
+++ b/clauseutils/clauseutils_test.go
@@ -1,0 +1,32 @@
+package clauseutils
+
+import (
+	"testing"
+)
+
+func TestAddOrOperator(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"foo", "foo"},
+		{"foo bar", "foo OR bar"},
+		{"foo     ", "foo"},
+		{"     foo", "foo"},
+		{"  foo   ", "foo"},
+		{"   foo bar ", "foo OR bar"},
+		{"  foo  bar  ", "foo OR bar"},
+		{" foo \n bar ", "foo OR bar"},
+		{" foo \n\t\n bar ", "foo OR bar"},
+		{" foo \nbar ", "foo OR bar"},
+		{" foo\n bar ", "foo OR bar"},
+		{" foo\n \nbar ", "foo OR bar"},
+	}
+
+	for _, c := range cases {
+		gotValue := AddOrOperator(c.input)
+		if gotValue != c.expected {
+			t.Errorf("Got %q but expected %q", gotValue, c.expected)
+		}
+	}
+}

--- a/clauseutils/clauseutils_test.go
+++ b/clauseutils/clauseutils_test.go
@@ -30,3 +30,23 @@ func TestAddOrOperator(t *testing.T) {
 		}
 	}
 }
+
+func TestAddImplicitWildcard(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"foo", "*foo*"},
+		{"foo OR bar", "*foo* OR *bar*"},
+		{"*foo OR bar", "*foo OR bar"},
+		{"\\foo", "\\foo"},
+		{"fo? OR x", "fo? OR x"},
+	}
+
+	for _, c := range cases {
+		gotValue := AddImplicitWildcard(c.input)
+		if gotValue != c.expected {
+			t.Errorf("Got %q but expected %q", gotValue, c.expected)
+		}
+	}
+}

--- a/clauseutils/clauseutils_test.go
+++ b/clauseutils/clauseutils_test.go
@@ -4,40 +4,17 @@ import (
 	"testing"
 )
 
-func TestAddOrOperator(t *testing.T) {
-	cases := []struct {
-		input    string
-		expected string
-	}{
-		{"foo", "foo"},
-		{"foo bar", "foo OR bar"},
-		{"foo     ", "foo"},
-		{"     foo", "foo"},
-		{"  foo   ", "foo"},
-		{"   foo bar ", "foo OR bar"},
-		{"  foo  bar  ", "foo OR bar"},
-		{" foo \n bar ", "foo OR bar"},
-		{" foo \n\t\n bar ", "foo OR bar"},
-		{" foo \nbar ", "foo OR bar"},
-		{" foo\n bar ", "foo OR bar"},
-		{" foo\n \nbar ", "foo OR bar"},
-	}
-
-	for _, c := range cases {
-		gotValue := AddOrOperator(c.input)
-		if gotValue != c.expected {
-			t.Errorf("Got %q but expected %q", gotValue, c.expected)
-		}
-	}
-}
-
 func TestAddImplicitWildcard(t *testing.T) {
 	cases := []struct {
 		input    string
 		expected string
 	}{
 		{"foo", "*foo*"},
-		{"foo OR bar", "*foo* OR *bar*"},
+		{"foo bar", "*foo* *bar*"},
+		{"foo\tbar", "*foo* *bar*"},
+		{"foo\n \nbar", "*foo* *bar*"},
+		{"foo OR bar", "*foo* *bar*"},
+		{"\"foo bar\"", "\"foo bar\""},
 		{"*foo OR bar", "*foo OR bar"},
 		{"\\foo", "\\foo"},
 		{"fo? OR x", "fo? OR x"},


### PR DESCRIPTION
This finishes implementing a label clause which is actually consistent with the current search field's behavior. What I've added:

* query string postprocessing utility functions, which turn spaces into `OR` operators and add implicit wildcards around things (these match the ones the UI currently does), plus using these in the clause
* the "exact" argument to the clause, which if set to true turns off the above postprocessing as used in the clause
* bunch of tests

The stuff I'm mimicing from the UI is in https://github.com/cyverse-de/ui/blob/master/de-lib/src/main/java/org/iplantc/de/client/services/impl/DataSearchQueryBuilder.java should you want to cross-reference.