### PR TITLE
Rewrite to use a QueryDSL object

### DIFF
--- a/clause/label/label.go
+++ b/clause/label/label.go
@@ -37,6 +37,6 @@ func LabelProcessor(args map[string]interface{}) (elastic.Query, error) {
 	return query, nil
 }
 
-func Register() {
-	querydsl.AddClauseType(typeKey, LabelProcessor, documentation)
+func Register(qd *querydsl.QueryDSL) {
+	qd.AddClauseType(typeKey, LabelProcessor, documentation)
 }


### PR DESCRIPTION
This way a given program can use several distinct sets of clauses in different parts of the program. Before it was set up such that all the state (the clause processors/documentation) were stored in class-level variables, so you would only be able to have one set of clauses available. This way, you instantiate a `*QueryDSL` and then that stores the processors and documentation, so it'd be possible to instead have, say, one object which translates for data searches and one for tag searches and one for app searches, instead of needing to put those into separate programs (of course, it's still possible to put them into separate services if desired, but I think it's worth having this option, particularly for tags vs. data, which might be necessary to enable tag-based search filtering).